### PR TITLE
fix: update tablename

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,7 +17,7 @@ resources:
   oci-image:
     type: oci-image
     description: GLAuth oci-image
-    upstream-source: ghcr.io/canonical/glauth:2.2.1
+    upstream-source: ghcr.io/canonical/glauth:2.3.0
 
 requires:
   pg-database:

--- a/src/database.py
+++ b/src/database.py
@@ -31,7 +31,7 @@ class User(Base):
 
 
 class Group(Base):
-    __tablename__ = "groups"
+    __tablename__ = "ldapgroups"
 
     id = mapped_column(Integer, primary_key=True)
     name: Mapped[str] = mapped_column(name="name", unique=True)


### PR DESCRIPTION
This PR updates the `groups` table name to `ldapgroups` to include the breaking change from v2.3.0.

Check https://github.com/canonical/glauth-utils/pull/8 for testing instructions.