### PR TITLE
fix(loki-rule): improve error handling in json parsing

### DIFF
--- a/src/loki_alert_rules/glauth_high_severity_log.rule
+++ b/src/loki_alert_rules/glauth_high_severity_log.rule
@@ -2,13 +2,13 @@ groups:
 - name: GLAuthHighSeverityLog
   rules:
   - alert: LowFrequencyHighSeverityLog
-    expr: sum by(level) (count_over_time({%%juju_topology%%} | json | level =~ `error|fatal|critical` [5m])) > 0 and sum by(level) (count_over_time({%%juju_topology%%} | json | level =~ `error|fatal|critical` [5m])) < 100
+    expr: sum by(level) (count_over_time({%%juju_topology%%} | json | __error__ != "JSONParserErr" | level =~ `error|fatal|critical` [5m])) > 0 and sum by(level) (count_over_time({%%juju_topology%%} | json | __error__ != "JSONParserErr" | level =~ `error|fatal|critical` [5m])) < 100
     labels:
       severity: warning
     annotations:
       summary: "Logs with level error or above found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs is low."
   - alert: HighFrequencyHighSeverityLog
-    expr: sum by(level) (count_over_time({%%juju_topology%%} | json | level =~ `error|fatal|critical` [5m])) > 100
+    expr: sum by(level) (count_over_time({%%juju_topology%%} | json | __error__ != "JSONParserErr" | level =~ `error|fatal|critical` [5m])) > 100
     labels:
       severity: error
     annotations:


### PR DESCRIPTION
# Description
This PR simply adds a LogQL `label filter` to avoid loki processing log entry that failed json parsing.

