### PR TITLE
feat: apply juju secrets to transfer bind account password

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,7 +17,7 @@ resources:
   oci-image:
     type: oci-image
     description: GLAuth oci-image
-    upstream-source: ghcr.io/canonical/glauth:2.3.0
+    upstream-source: ghcr.io/canonical/glauth:2.3.1
 
 requires:
   pg-database:

--- a/src/charm.py
+++ b/src/charm.py
@@ -238,6 +238,7 @@ class GLAuthCharm(CharmBase):
 
         self._handle_event_update(event)
 
+    @leader_unit
     @validate_database_resource
     def _on_ldap_requested(self, event: LdapRequestedEvent) -> None:
         if not (requirer_data := event.data):

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -1,3 +1,6 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 import hashlib
 import logging
 import subprocess
@@ -39,9 +42,9 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class BindAccount:
-    cn: Optional[str] = None
-    ou: Optional[str] = None
-    password: Optional[str] = None
+    cn: str
+    ou: str
+    password: str
 
 
 def _create_bind_account(dsn: str, user_name: str, group_name: str) -> BindAccount:
@@ -106,7 +109,7 @@ class LdapIntegration:
             url=self.ldap_url,
             base_dn=self.base_dn,
             bind_dn=f"cn={self._bind_account.cn},ou={self._bind_account.ou},{self.base_dn}",
-            bind_password_secret=self._bind_account.password or "",
+            bind_password_secret=self._bind_account.password,
             auth_method="simple",
             starttls=self.starttls_enabled,
         )
@@ -146,7 +149,10 @@ class CertificatesIntegration:
             key="glauth-server-cert",
             peer_relation_name="glauth-peers",
             cert_subject=hostname,
-            extra_sans_dns=[hostname],
+            extra_sans_dns=[
+                hostname,
+                f"{charm.app.name}.{charm.model.name}.svc.cluster.local",
+            ],
         )
 
     @property

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -118,6 +118,7 @@ async def test_ldap_integration(
     assert ldap_integration_data["bind_dn"].startswith(
         f"cn={GLAUTH_CLIENT_APP},ou={ops_test.model_name}"
     )
+    assert ldap_integration_data["bind_password_secret"].startswith("secret:")
 
 
 async def test_certificate_transfer_integration(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -196,9 +196,12 @@ class TestLdapRequestedEvent:
         ldap_relation_data: MagicMock,
     ) -> None:
         assert isinstance(harness.model.unit.status, ActiveStatus)
-        assert LDAP_PROVIDER_DATA.model_dump() == harness.get_relation_data(
-            ldap_relation, harness.model.app.name
-        )
+
+        actual = dict(harness.get_relation_data(ldap_relation, harness.model.app.name))
+        secret_id = actual.get("bind_password_secret")
+        secret_content = harness.model.get_secret(id=secret_id).get_content()
+        actual["bind_password_secret"] = secret_content.get("password")
+        assert LDAP_PROVIDER_DATA.model_dump() == actual
 
 
 class TestLdapAuxiliaryRequestedEvent:


### PR DESCRIPTION
This pull request tries to use the Juju secret to encapsulate the bind account password passed to the requirer charm. The main logic is generally done in the `ldap` charm library so that the provider charm does not need to know it.

Please note that I intentionally leave the requirer side this time. Will chat with the stakeholders about how they wanna deal with the secret.