### PR TITLE
Iam 998

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,7 +33,6 @@ jobs:
           provider: microk8s
           channel: 1.28-strict/stable
           juju-channel: 3.4
-          bootstrap-options: '--agent-version=3.4.0'
 
       - name: Run integration tests
         run: tox -e integration -- --model testing

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -35,6 +35,10 @@ requires:
     interface: tls-certificates
     limit: 1
     optional: true
+  ldap-client:
+    description: |
+      Use another ldap server as a backend
+    interface: ldap
 
 provides:
   metrics-endpoint:

--- a/src/configs.py
+++ b/src/configs.py
@@ -3,7 +3,7 @@
 
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, List, Mapping, Optional
+from typing import Any, Mapping, Optional
 
 from charms.glauth_k8s.v0.ldap import LdapProviderData, LdapRequirer
 from jinja2 import Template
@@ -53,18 +53,12 @@ class DatabaseConfig:
 
 @dataclass
 class LdapServerConfig:
-    ldap_servers: Optional[List[LdapProviderData]] = None
+    ldap_server: Optional[LdapProviderData] = None
 
     @classmethod
     def load(cls, requirer: LdapRequirer) -> Optional["LdapServerConfig"]:
-        if not (ldap_integrations := requirer.relations):
+        if not (ldap_servers := requirer.consume_ldap_relation_data()):
             return None
-
-        ldap_servers = [
-            data
-            for i in ldap_integrations
-            if (data := requirer.consume_ldap_relation_data(relation=i))
-        ]
 
         return LdapServerConfig(ldap_servers)
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,6 +4,7 @@
 from pathlib import Path, PurePath
 from string import Template
 
+LDAP_CLIENT_INTEGRATION_NAME = "ldap-client"
 DATABASE_INTEGRATION_NAME = "pg-database"
 LOKI_API_PUSH_INTEGRATION_NAME = "logging"
 PROMETHEUS_SCRAPE_INTEGRATION_NAME = "metrics-endpoint"

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -108,7 +108,7 @@ class LdapIntegration:
     @property
     def provider_base_data(self) -> LdapProviderBaseData:
         return LdapProviderBaseData(
-            url=self.ldap_url,
+            urls=[self.ldap_url],
             base_dn=self.base_dn,
             starttls=self.starttls_enabled,
         )
@@ -119,7 +119,7 @@ class LdapIntegration:
             return None
 
         return LdapProviderData(
-            url=self.ldap_url,
+            urls=[self.ldap_url],
             base_dn=self.base_dn,
             bind_dn=f"cn={self._bind_account.cn},ou={self._bind_account.ou},{self.base_dn}",
             bind_password=self._bind_account.password,

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -85,7 +85,9 @@ class LdapIntegration:
         self._bind_account: Optional[BindAccount] = None
 
     def load_bind_account(self, user: str, group: str, relation_id: int) -> None:
-        database_config = DatabaseConfig.load(self._charm.database_requirer)
+        if not (database_config := DatabaseConfig.load(self._charm.database_requirer)):
+            return
+
         self._bind_account = _create_bind_account(database_config.dsn, user, group)
         if not self._bind_account.password:
             password = self._charm.ldap_provider.get_bind_password(relation_id)
@@ -134,7 +136,8 @@ class AuxiliaryIntegration:
 
     @property
     def auxiliary_data(self) -> AuxiliaryData:
-        database_config = DatabaseConfig.load(self._charm.database_requirer)
+        if not (database_config := DatabaseConfig.load(self._charm.database_requirer)):
+            return AuxiliaryData()
 
         return AuxiliaryData(
             database=database_config.database,

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -101,15 +101,15 @@ class LdapIntegration:
     def load_bind_account_from_remote_ldap(self) -> None:
         ldap_config = LdapServerConfig.load(self._charm.ldap_requirer)
 
-        if not ldap_config or not ldap_config.ldap_servers or len(ldap_config.ldap_servers) < 1:
-            return
-        server = ldap_config.ldap_servers[0]
-        if not isinstance(server, LdapProviderData):
+        if not ldap_config or not ldap_config.ldap_server:
             return
 
-        bind_dn = {part.split("=")[0]: part.split("=")[1] for part in server.bind_dn.split(",")}
+        bind_dn = {
+            part.split("=")[0]: part.split("=")[1]
+            for part in ldap_config.ldap_server.bind_dn.split(",")
+        }
         self._bind_account = BindAccount(
-            bind_dn.get("cn", ""), bind_dn.get("ou", ""), server.bind_password
+            bind_dn.get("cn", ""), bind_dn.get("ou", ""), ldap_config.ldap_server.bind_password
         )
 
     @property

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -3,6 +3,7 @@
 
 import hashlib
 import logging
+import socket
 import subprocess
 from contextlib import suppress
 from dataclasses import dataclass
@@ -97,7 +98,8 @@ class LdapIntegration:
 
     @property
     def ldap_url(self) -> str:
-        return f"ldap://{self._charm.config.get('hostname')}:{GLAUTH_LDAP_PORT}"
+        hostname = self._charm.config.get("hostname") or socket.getfqdn()
+        return f"ldap://{hostname}:{GLAUTH_LDAP_PORT}"
 
     @property
     def base_dn(self) -> str:

--- a/src/utils.py
+++ b/src/utils.py
@@ -5,11 +5,19 @@ import logging
 from functools import wraps
 from typing import Any, Callable, Optional
 
+from ops import ModelError
 from ops.charm import CharmBase, EventBase
 from ops.model import BlockedStatus, WaitingStatus
 from tenacity import Retrying, TryAgain, wait_fixed
 
-from constants import GLAUTH_CONFIG_FILE, SERVER_CERT, SERVER_KEY
+from constants import (
+    DATABASE_INTEGRATION_NAME,
+    GLAUTH_CONFIG_FILE,
+    LDAP_CLIENT_INTEGRATION_NAME,
+    SERVER_CERT,
+    SERVER_KEY,
+    WORKLOAD_SERVICE,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +28,18 @@ Condition = Callable[[CharmBase], ConditionEvaluation]
 def container_not_connected(charm: CharmBase) -> ConditionEvaluation:
     not_connected = not charm._container.can_connect()
     return not_connected, ("Container is not connected yet" if not_connected else "")
+
+
+def service_not_ready(charm: CharmBase) -> ConditionEvaluation:
+    if not charm._container.can_connect():
+        return True, "Container is not connected yet"
+
+    try:
+        service = charm._container.get_service(WORKLOAD_SERVICE)
+    except (ModelError, RuntimeError):
+        return True, "Pebble service is not ready"
+    is_not_running = not service.is_running()
+    return is_not_running, ("Pebble service is not ready" if is_not_running else "")
 
 
 def integration_not_exists(integration_name: str) -> Condition:
@@ -40,6 +60,38 @@ def tls_certificates_not_ready(charm: CharmBase) -> ConditionEvaluation:
 def database_not_ready(charm: CharmBase) -> ConditionEvaluation:
     not_exists = not charm.database_requirer.is_resource_created()
     return not_exists, ("Waiting for database creation" if not_exists else "")
+
+
+def ldap_provider_not_ready(charm: CharmBase) -> ConditionEvaluation:
+    not_ready = not charm.ldap_requirer.ready()
+    return not_ready, ("Waiting for ldap user creation" if not_ready else "")
+
+
+def backend_integration_not_exists(charm: CharmBase) -> ConditionEvaluation:
+    if (
+        not charm.model.relations[DATABASE_INTEGRATION_NAME]
+        and not charm.model.relations[LDAP_CLIENT_INTEGRATION_NAME]
+    ):
+        return (
+            True,
+            f"Backend integration (`{DATABASE_INTEGRATION_NAME}` or `{LDAP_CLIENT_INTEGRATION_NAME}`) missing",
+        )
+
+    return False, ""
+
+
+def backend_not_ready(charm: CharmBase) -> ConditionEvaluation:
+    if charm.model.relations[DATABASE_INTEGRATION_NAME]:
+        not_ready, msg = database_not_ready(charm)
+        if not_ready:
+            return not_ready, msg
+
+    if charm.model.relations[LDAP_CLIENT_INTEGRATION_NAME]:
+        not_ready, msg = ldap_provider_not_ready(charm)
+        if not_ready:
+            return not_ready, msg
+
+    return False, ""
 
 
 def block_when(*conditions: Condition) -> Callable:

--- a/templates/glauth.cfg.j2
+++ b/templates/glauth.cfg.j2
@@ -11,13 +11,11 @@ structuredlog = true
 [ldaps]
   enabled = false
 
-{%- if ldap_servers %}
-{%   for ldap_server in ldap_servers.ldap_servers %}
+{% if ldap_server %}
 [[backends]]
   datastore = "ldap"
-  servers = {{ ldap_server.urls | list }}
-{%   endfor %}
-{% endif -%}
+  servers = {{ ldap_server.ldap_server.urls | list }}
+{% endif %}
 
 {%- if database %}
 [[backends]]
@@ -26,7 +24,7 @@ structuredlog = true
   pluginhandler = "NewPostgresHandler"
   baseDN = "{{ base_dn }}"
   database = "postgres://{{ database.get('username') }}:{{ database.get('password') }}@{{ database.get('endpoint') }}/{{ database.get('database') }}?sslmode=disable"
-{% endif -%}
+{% endif %}
 
 [behaviors]
   # Ignore all capabilities restrictions, for instance allowing every user to perform a search

--- a/templates/glauth.cfg.j2
+++ b/templates/glauth.cfg.j2
@@ -11,12 +11,22 @@ structuredlog = true
 [ldaps]
   enabled = false
 
-[backend]
+{%- if ldap_servers %}
+{%   for ldap_server in ldap_servers.ldap_servers %}
+[[backends]]
+  datastore = "ldap"
+  servers = {{ ldap_server.urls | list }}
+{%   endfor %}
+{% endif -%}
+
+{%- if database %}
+[[backends]]
   datastore = "plugin"
   plugin = "/bin/postgres.so"
   pluginhandler = "NewPostgresHandler"
   baseDN = "{{ base_dn }}"
   database = "postgres://{{ database.get('username') }}:{{ database.get('password') }}@{{ database.get('endpoint') }}/{{ database.get('database') }}?sslmode=disable"
+{% endif -%}
 
 [behaviors]
   # Ignore all capabilities restrictions, for instance allowing every user to perform a search

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,6 +15,7 @@ from pytest_operator.plugin import OpsTest
 METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 CERTIFICATE_PROVIDER_APP = "self-signed-certificates"
 DB_APP = "postgresql-k8s"
+GLAUTH_PROXY = "ldap-proxy"
 GLAUTH_APP = METADATA["name"]
 GLAUTH_IMAGE = METADATA["resources"]["oci-image"]["upstream-source"]
 GLAUTH_CLIENT_APP = "any-charm"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -15,6 +15,7 @@ from conftest import (
     GLAUTH_APP,
     GLAUTH_CLIENT_APP,
     GLAUTH_IMAGE,
+    GLAUTH_PROXY,
     extract_certificate_common_name,
 )
 from pytest_operator.plugin import OpsTest
@@ -65,12 +66,22 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
         trust=True,
         series="jammy",
     )
+    await ops_test.model.deploy(
+        str(charm_path),
+        resources={"oci-image": GLAUTH_IMAGE},
+        application_name=GLAUTH_PROXY,
+        config={"starttls_enabled": True},
+        trust=True,
+        series="jammy",
+    )
 
     await ops_test.model.integrate(GLAUTH_APP, CERTIFICATE_PROVIDER_APP)
+    await ops_test.model.integrate(GLAUTH_PROXY, CERTIFICATE_PROVIDER_APP)
     await ops_test.model.integrate(GLAUTH_APP, DB_APP)
+    await ops_test.model.integrate(f"{GLAUTH_PROXY}:ldap-client", f"{GLAUTH_APP}:ldap")
 
     await ops_test.model.wait_for_idle(
-        apps=[CERTIFICATE_PROVIDER_APP, DB_APP, GLAUTH_CLIENT_APP, GLAUTH_APP],
+        apps=[CERTIFICATE_PROVIDER_APP, DB_APP, GLAUTH_CLIENT_APP, GLAUTH_APP, GLAUTH_PROXY],
         status="active",
         raise_on_blocked=False,
         timeout=1000,
@@ -117,6 +128,27 @@ async def test_ldap_integration(
     assert ldap_integration_data
     assert ldap_integration_data["bind_dn"].startswith(
         f"cn={GLAUTH_CLIENT_APP},ou={ops_test.model_name}"
+    )
+    assert ldap_integration_data["bind_password_secret"].startswith("secret:")
+
+
+async def test_ldap_client_integration(
+    ops_test: OpsTest,
+    app_integration_data: Callable,
+) -> None:
+    await ops_test.model.wait_for_idle(
+        apps=[GLAUTH_APP, GLAUTH_PROXY],
+        status="active",
+        timeout=1000,
+    )
+
+    ldap_integration_data = app_integration_data(
+        GLAUTH_PROXY,
+        "ldap-client",
+    )
+    assert ldap_integration_data
+    assert ldap_integration_data["bind_dn"].startswith(
+        f"cn={GLAUTH_PROXY},ou={ops_test.model_name}"
     )
     assert ldap_integration_data["bind_password_secret"].startswith("secret:")
 

--- a/tests/integration/tester.py
+++ b/tests/integration/tester.py
@@ -37,7 +37,7 @@ class AnyCharm(AnyCharmBase):
 
     def _on_ldap_ready(self, event: LdapReadyEvent) -> None:
         ldap_data = self.ldap_requirer.consume_ldap_relation_data(
-            event.relation.id,
+            relation=event.relation,
         )
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -27,7 +27,7 @@ DB_ENDPOINTS = "postgresql-k8s-primary.namespace.svc.cluster.local:5432"
 
 LDAP_CLIENT_APP = "ldap-client"
 LDAP_PROVIDER_DATA = LdapProviderData(
-    url="ldap://ldap.glauth.com",
+    urls=["ldap://ldap.glauth.com"],
     base_dn="dc=glauth,dc=com",
     bind_dn="cn=user,ou=group,dc=glauth,dc=com",
     bind_password="password",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -234,7 +234,7 @@ class TestLdapRequestedEvent:
         assert isinstance(harness.model.unit.status, ActiveStatus)
 
         actual = dict(harness.get_relation_data(ldap_relation, harness.model.app.name))
-        assert LDAP_PROVIDER_DATA.model_dump(by_alias=True) == actual
+        assert LDAP_PROVIDER_DATA.model_dump() == actual
 
 
 class TestLdapAuxiliaryRequestedEvent:

--- a/unit-requirements.txt
+++ b/unit-requirements.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 coverage[toml]
 cryptography
+ipdb
 jsonschema
 pytest
 pytest-mock


### PR DESCRIPTION
IAM-998

Allow glauth to act as an ldap broker. The main problem with the current approach is that the ldap requests are proxied to the remote ldap server as they are, which means that we have to provide the same bind_dn and password to all the applications that relate with the proxy. Not much we can do on that end (other than push upstream).

Question:
- Should we allow for multiple backends?
- Split integration tests in multiple files?

TODO:
- In another PR we will refactor the integration tests to perform some basic ldap search