### PR TITLE
chose: loose Pydantic 2 version constraint

### DIFF
--- a/lib/charms/glauth_k8s/v0/ldap.py
+++ b/lib/charms/glauth_k8s/v0/ldap.py
@@ -155,9 +155,9 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
-PYDEPS = ["pydantic~=2.5.3"]
+PYDEPS = ["pydantic>=2.5.3"]
 
 DEFAULT_RELATION_NAME = "ldap"
 BIND_ACCOUNT_SECRET_LABEL_TEMPLATE = Template("relation-$relation_id-bind-account-secret")

--- a/src/database.py
+++ b/src/database.py
@@ -55,7 +55,7 @@ class Operation:
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         if exc_type:
             logger.error(
-                f"The database operation failed. The exception " f"{exc_type} raised: {exc_val}"
+                f"The database operation failed. The exception {exc_type} raised: {exc_val}"
             )
             self._session.rollback()
         else:


### PR DESCRIPTION
This PR loose the constraints around the Pydantic dependency to allow versions bigger than `2.5.x`.

This change is required so other charms could use this charm's library, without needing to stick to Pydantic `2.5.x`