### PR TITLE
feat: add `anonymousdse_enabled` config option

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -87,6 +87,16 @@ config:
         Enable the StartTLS support or not. DO NOT TURN IT OFF IN PRODUCTION.
       default: true
       type: boolean
+    anonymousdse_enabled:
+      description: |
+        Allow anonymous requests to the root directory server agent service entry (root DSE).
+
+        Anonymous request MUST be enabled for applications like SSSD to 
+        successfully bind to the Glauth server. Anonymous requests should
+        be disabled if not integrating with applications that must first
+        anonymously query the root DSE before binding to an LDAP server.
+      default: false
+      type: boolean
 
 
 base: ubuntu@22.04

--- a/src/charm.py
+++ b/src/charm.py
@@ -150,6 +150,7 @@ class GLAuthCharm(CharmBase):
 
         self.config_file = ConfigFile(
             base_dn=self.config.get("base_dn"),
+            anonymousdse_enabled=self.config.get("anonymousdse_enabled"),
             starttls_config=StartTLSConfig.load(self.config),
         )
         self._ldap_integration = LdapIntegration(self)
@@ -237,6 +238,7 @@ class GLAuthCharm(CharmBase):
 
     def _on_config_changed(self, event: ConfigChangedEvent) -> None:
         self.config_file.base_dn = self.config.get("base_dn")
+        self.config_file.anonymousdse_enabled = self.config.get("anonymousdse_enabled")
         self._handle_event_update(event)
         self.ldap_provider.update_relations_app_data(self._ldap_integration.provider_base_data)
 

--- a/src/configs.py
+++ b/src/configs.py
@@ -78,6 +78,7 @@ class StartTLSConfig:
 @dataclass
 class ConfigFile:
     base_dn: Optional[str] = None
+    anonymousdse_enabled: bool = False
     database_config: Optional[DatabaseConfig] = None
     starttls_config: Optional[StartTLSConfig] = None
     ldap_servers_config: Optional[LdapServerConfig] = None
@@ -95,6 +96,7 @@ class ConfigFile:
         starttls_config = asdict(self.starttls_config) if self.starttls_config else None
         rendered = template.render(
             base_dn=self.base_dn,
+            anonymousdse_enabled=self.anonymousdse_enabled,
             database=database_config,
             ldap_servers=ldap_servers_config,
             starttls=starttls_config,

--- a/templates/glauth.cfg.j2
+++ b/templates/glauth.cfg.j2
@@ -24,6 +24,7 @@ structuredlog = true
   pluginhandler = "NewPostgresHandler"
   baseDN = "{{ base_dn }}"
   database = "postgres://{{ database.get('username') }}:{{ database.get('password') }}@{{ database.get('endpoint') }}/{{ database.get('database') }}?sslmode=disable"
+  anonymousdse = {{ "true" if anonymousdse_enabled else "false" }}
 {% endif %}
 
 [behaviors]


### PR DESCRIPTION
`anonymousdse` must be enabled for applications like SSSD to successfully bind to the Glauth server, but it's recommended to keep the option set to false if you're not using applications that need to anonymously query the root DSE. See the Glauth [Security](https://glauth.github.io/docs/security.html) documentation for more info. 

This option is needed for the SSSD operator in Charmed HPC to successfully bind to the Glauth service, otherwise the SSSD service will silently fail in background with the error message `Insufficient permissions (50)`. Once `anonymousdse` is enabled, SSSD successfully binds to Glauth if also using the patches provided in #78.  