### PR TITLE
fix: update the tls certificate in ingress-per-unit integration

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,6 +33,7 @@ jobs:
           provider: microk8s
           channel: 1.31-strict/stable
           juju-channel: 3.6
+          microk8s-addons: "dns hostpath-storage metallb:10.64.140.43-10.64.140.49"
 
       - name: Run integration tests
         run: tox -e build-prerequisites,integration -- --model testing

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -181,14 +181,17 @@ class CertificatesIntegration:
         self._container = charm._container
 
         hostname = charm.config.get("hostname")
+        sans = [hostname, f"{charm.app.name}.{charm.model.name}.svc.cluster.local"]
+
+        if ingress := charm.ingress_per_unit.url:
+            ingress_domain, *_ = ingress.rsplit(sep=":", maxsplit=1)
+            sans.append(ingress_domain)
+
         self.cert_handler = CertHandler(
             charm,
             key="glauth-server-cert",
             cert_subject=hostname,
-            sans=[
-                hostname,
-                f"{charm.app.name}.{charm.model.name}.svc.cluster.local",
-            ],
+            sans=sans,
         )
 
     @property


### PR DESCRIPTION
This pull request tries to resolve the https://github.com/canonical/glauth-k8s-operator/issues/86.

The charm now will observe the events triggered from `ingress-per-unit` integration, and update the certificates correspondingly.