### PR TITLE
feat: add module for deploying glauth-k8s with terraform 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,8 @@ cython_debug/
 .idea/
 
 *.charm
+
+# Terraform
+.terraform
+.terraform.lock.hcl
+*.tfstate*

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,51 @@
+# Terraform module for glauth-k8s
+
+This is a Terraform module facilitating the deployment of the glauth-k8s charm using
+the [Juju Terraform provider](https://github.com/juju/terraform-provider-juju).
+For more information, refer to the
+[documentation](https://registry.terraform.io/providers/juju/juju/latest/docs)
+for the Juju Terraform provider.
+
+## Requirements
+
+This module requires a Juju model to be available. Refer to the [usage](#usage)
+section for more details.
+
+## API
+
+### Inputs
+
+This module offers the following configurable units:
+
+| Name          | Type        | Description                                              | Default       | Required |
+|---------------|-------------|----------------------------------------------------------|---------------|:--------:|
+| `app_name`    | string      | Application name                                         | glauth-k8s    |          |
+| `base`        | string      | Base version to use for deployed machine                 | ubuntu@22.04  |          |
+| `channel`     | string      | Channel that charm is deployed from                      | latest/stable |          |
+| `config`      | map(string) | Map of charm configuration options to pass at deployment | {}            |          |
+| `constraints` | string      | Constraints for the charm deployment                     | "arch=amd64"  |          |
+| `model_name`  | string      | Name of the model to deploy the charm to                 |               |    Y     |
+| `revision`    | number      | Revision number of charm to deploy                       | null          |          |
+| `units`       | number      | Number of units to deploy                                | 1             |          |
+
+### Outputs
+
+After applying, the module exports the following outputs:
+
+| Name       | Description                 |
+|------------|-----------------------------|
+| `app_name` | Application name            |
+| `provides` | Map of `provides` endpoints |
+| `requires` | Map of `requires` endpoints |
+
+## Usage
+
+Users should ensure that Terraform is aware of the Juju model dependency of the
+charm module.
+
+To deploy this module with its required dependency, you can run
+the following command:
+
+```shell
+terraform apply -var="model_name=<MODEL_NAME>" -auto-approve
+```

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,18 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "glauth-k8s" {
+  name  = var.app_name
+  model = var.model_name
+
+  charm {
+    name     = "glauth-k8s"
+    base     = var.base
+    channel  = var.channel
+    revision = var.revision
+  }
+
+  config      = var.config
+  constraints = var.constraints
+  units       = var.units
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,26 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_name" {
+  value = juju_application.glauth-k8s.name
+}
+
+output "requires" {
+  value = {
+    pg-database  = "pg-database"
+    logging      = "logging"
+    certificates = "certificates"
+    ingress      = "ingress"
+    ldap-client  = "ldap-client"
+  }
+}
+
+output "provides" {
+  value = {
+    metrics-endpoint  = "metrics-endpoint"
+    grafana-dashboard = "grafana-dashboard"
+    ldap              = "ldap"
+    glauth-auxiliary  = "glauth-auxiliary"
+    send-ca-cert      = "send-ca-cert"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,50 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "glauth-k8s"
+}
+
+variable "base" {
+  description = "Charm base"
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = "latest/stable"
+}
+
+variable "config" {
+  description = "Charm configuration"
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Deployment constraints"
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  nullable    = true
+  default     = null
+}
+
+variable "units" {
+  description = "Number of units"
+  type        = number
+  default     = 1
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,11 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.16.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a Terraform module for deploying glauth-k8s. The module can be used like so to deploy the glauth-k8s charm in a k8s cloud:

```terraform
terraform {
  required_providers {
    juju = {
      source  = "juju/juju"
      version = ">= 0.16.0"
    }
  }
}

provider "juju" {}

resource "juju_model" "idm" {
  name = "idm-stack"
}

module glauth-k8s {
  source = "git::https://github.com/canonical/glauth-k8s-operator//terraform"

  module_name = juju_model.idm.name
}
```

We need this module since it makes it much easier to deploy glauth-k8s with our HPC charms + integrate with SSSD.