### PR TITLE
refactor: remove the charm config `hostname`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,12 @@ juju integrate glauth-k8s self-signed-certificates
 
 ## Observability
 
-GLAuth operator integrates with [Canonical Observability Stack (COS)](https://charmhub.io/topics/canonical-observability-stack) bundle. It comes with a Grafana dashboard and Loki and Prometheus alert rules for basic common scenarios. To integrate with the COS bundle, after you [deploy](https://charmhub.io/topics/canonical-observability-stack/tutorials/install-microk8s#heading--deploy-the-cos-lite-bundle) it, you can run:
+GLAuth operator integrates
+with [Canonical Observability Stack (COS)](https://charmhub.io/topics/canonical-observability-stack)
+bundle. It comes with a Grafana dashboard and Loki and Prometheus alert rules
+for basic common scenarios. To integrate with the COS bundle, after
+you [deploy](https://charmhub.io/topics/canonical-observability-stack/tutorials/install-microk8s#heading--deploy-the-cos-lite-bundle)
+it, you can run:
 
 ```shell
 juju integrate glauth-k8s:metrics-endpoint prometheus:metrics-endpoint
@@ -109,16 +114,16 @@ juju integrate glauth-k8s:grafana-dashboard grafana:grafana-dashboard
 The `glauth-k8s` charmed operator offers the following charm configuration
 options.
 
-| Charm Config Option | Description                                                      | Example                                              |
-| :-----------------: | ---------------------------------------------------------------- | ---------------------------------------------------- |
-|      `base_dn`      | The portion of the DIT in which to search for matching entries   | `juju config <charm-app> base-dn="dc=glauth,dc=com"` |
-|     `hostname`      | The hostname of the LDAP server in `glauth-k8s` charmed operator | `juju config <charm-app> hostname="ldap.glauth.com"` |
-| `starttls_enabled`  | The switch to enable/disable StartTLS support                    | `juju config <charm-app> starttls_enabled=true`      |
+|  Charm Config Option   | Description                                                    | Example                                              |
+|:----------------------:|----------------------------------------------------------------|------------------------------------------------------|
+|       `base_dn`        | The portion of the DIT in which to search for matching entries | `juju config <charm-app> base-dn="dc=glauth,dc=com"` |
+|   `starttls_enabled`   | The switch to enable/disable StartTLS support                  | `juju config <charm-app> starttls_enabled=true`      |
+| `anonymousdse_enabled` | The switch to enable/disable anonymous access to the root DSE  | `juju config <charm-app> anonymousdse_enabled=true`  |
 
 > ⚠️ **NOTE**
 >
-> - The `hostname` should **NOT** contain the ldap scheme (e.g. `ldap://`) and port.
-> - Please refer to the `config.yaml` for more details about the configurations.
+> - Please refer to the `charmcraft.yaml` for more details about the
+    configurations.
 
 ## Contributing
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -79,13 +79,6 @@ config:
       description: The base DN
       default: "dc=glauth,dc=com"
       type: string
-    hostname:
-      description: |
-        The hostname of the LDAP server.
-
-        The hostname should NOT contain the LDAP scheme (e.g. ldap://) and port.
-      default: "ldap.glauth.com"
-      type: string
     starttls_enabled:
       description: |
         Enable the StartTLS support or not. DO NOT TURN IT OFF IN PRODUCTION.
@@ -95,7 +88,7 @@ config:
       description: |
         Allow anonymous requests to the root directory server agent service entry (root DSE).
 
-        Anonymous request MUST be enabled for applications like SSSD to 
+        Anonymous request MUST be enabled for applications like SSSD to
         successfully bind to the Glauth server. Anonymous requests should
         be disabled if not integrating with applications that must first
         anonymously query the root DSE before binding to an LDAP server.

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -3,7 +3,6 @@
 
 import hashlib
 import logging
-import socket
 import subprocess
 from contextlib import suppress
 from dataclasses import dataclass
@@ -117,7 +116,7 @@ class LdapIntegration:
         if ingress := self._charm.ingress_per_unit.urls:
             return [f"ldap://{url}" for url in ingress.values()]
 
-        url = self._charm.config.get("hostname") or socket.getfqdn()
+        url = f"{self._charm.app.name}.{self._charm.model.name}.svc.cluster.local"
         return [f"ldap://{url}:{GLAUTH_LDAP_PORT}"]
 
     @property
@@ -180,8 +179,8 @@ class CertificatesIntegration:
         self._charm = charm
         self._container = charm._container
 
-        hostname = charm.config.get("hostname")
-        sans = [hostname, f"{charm.app.name}.{charm.model.name}.svc.cluster.local"]
+        k8s_svc_host = f"{charm.app.name}.{charm.model.name}.svc.cluster.local"
+        sans = [k8s_svc_host]
 
         if ingress := charm.ingress_per_unit.url:
             ingress_domain, *_ = ingress.rsplit(sep=":", maxsplit=1)
@@ -190,7 +189,7 @@ class CertificatesIntegration:
         self.cert_handler = CertHandler(
             charm,
             key="glauth-server-cert",
-            cert_subject=hostname,
+            cert_subject=k8s_svc_host,
             sans=sans,
         )
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -121,13 +121,17 @@ async def test_ingress_per_unit_integration(ingress_url: Optional[str]) -> None:
 
 
 async def test_certification_integration(
+    ops_test: OpsTest,
     certificate_integration_data: Optional[dict],
     ingress_ip: Optional[str],
 ) -> None:
     assert certificate_integration_data
     certificates = json.loads(certificate_integration_data["certificates"])
     certificate = certificates[0]["certificate"]
-    assert "CN=ldap.glauth.com" == extract_certificate_common_name(certificate)
+    assert (
+        f"CN={GLAUTH_APP}.{ops_test.model_name}.svc.cluster.local"
+        == extract_certificate_common_name(certificate)
+    )
     assert ingress_ip in extract_certificate_sans(certificate)
 
 
@@ -204,7 +208,10 @@ async def test_certificate_transfer_integration(
     assert isinstance(json.loads(chain), list), "Invalid certificate chain."
 
     certificate = certificate_transfer_integration_data["certificate"]
-    assert "CN=ldap.glauth.com" == extract_certificate_common_name(certificate)
+    assert (
+        f"CN={GLAUTH_APP}.{ops_test.model_name}.svc.cluster.local"
+        == extract_certificate_common_name(certificate)
+    )
     assert ingress_ip in extract_certificate_sans(certificate)
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -63,7 +63,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
         ops_test.model.deploy(
             TRAEFIK_CHARM,
             application_name=INGRESS_APP,
-            channel="latest/edge",
+            channel="latest/stable",
             trust=True,
         ),
     )


### PR DESCRIPTION
This pull request removes the hostname charm configuration for the following reasons:

- The `hostname` config was initially introduced when the charm was developed, before ingress came into the picture. With ingress now in place, `hostname` is redundant and may cause confusion for clients as it overlaps with the ingress host.
- Kubernetes service DNS or the ingress hostname/IP already provides a stable address for glauth units, eliminating the need for an additional configuration parameter.
- The CertHandler component can cause TLS private key and certificate mismatches when `hostname` is updated, leading to potential out-of-sync issues. This also raises a separate consideration: replacing `CertHandler` with the `tls-certificate` v4 library for improved reliability.

By removing `hostname`, we can simplify the charm configuration while ensuring consistency in service discovery and TLS management.

Also resolves the https://github.com/canonical/glauth-k8s-operator/issues/95