### PR TITLE
Add pydantic V1 support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
         run: python -m pip install tox
 
       - name: Run tests
-        run: tox -e unit
+        run: tox -e unit,unit-pydantic-v1
 
   integration-test-microk8s:
     name: Integration tests (microk8s)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -117,8 +117,10 @@ async def unit_integration_data(ops_test: OpsTest) -> Callable:
 
 
 @pytest_asyncio.fixture
-async def ldap_integration_data(app_integration_data: Callable) -> Optional[dict]:
-    return await app_integration_data(GLAUTH_CLIENT_APP, "ldap")
+async def ldap_integration_data(
+    app_integration_data: Callable, ldap_client_app_name: str
+) -> Optional[dict]:
+    return await app_integration_data(ldap_client_app_name, "ldap")
 
 
 @pytest_asyncio.fixture
@@ -130,6 +132,7 @@ async def database_integration_data(ops_test: OpsTest, app_integration_data: Cal
         show_secrets=True,
     )
     db_credential = next(iter(db_credentials), None)
+    assert db_credential
     decoded_db_credentials = {
         field: b64decode(db_credential.value.data[field]).decode("utf-8")
         for field in ("username", "password")

--- a/tests/integration/db.sql
+++ b/tests/integration/db.sql
@@ -1,18 +1,18 @@
-INSERT INTO ldapgroups(name, gidnumber) VALUES('superheros', 5502);
-INSERT INTO ldapgroups(name, gidnumber) VALUES('svcaccts', 5503);
-INSERT INTO ldapgroups(name, gidnumber) VALUES('civilians', 5504);
-INSERT INTO ldapgroups(name, gidnumber) VALUES('caped', 5505);
-INSERT INTO ldapgroups(name, gidnumber) VALUES('lovesailing', 5506);
-INSERT INTO ldapgroups(name, gidnumber) VALUES('smoker', 5507);
+INSERT INTO ldapgroups(name, gidnumber) VALUES('superheros', 5502) ON CONFLICT DO NOTHING;
+INSERT INTO ldapgroups(name, gidnumber) VALUES('svcaccts', 5503) ON CONFLICT DO NOTHING;
+INSERT INTO ldapgroups(name, gidnumber) VALUES('civilians', 5504) ON CONFLICT DO NOTHING;
+INSERT INTO ldapgroups(name, gidnumber) VALUES('caped', 5505) ON CONFLICT DO NOTHING;
+INSERT INTO ldapgroups(name, gidnumber) VALUES('lovesailing', 5506) ON CONFLICT DO NOTHING;
+INSERT INTO ldapgroups(name, gidnumber) VALUES('smoker', 5507) ON CONFLICT DO NOTHING;
 
-INSERT INTO includegroups(parentgroupid, includegroupid) VALUES(5504, 5502);
-INSERT INTO includegroups(parentgroupid, includegroupid) VALUES(5505, 5503);
-INSERT INTO includegroups(parentgroupid, includegroupid) VALUES(5505, 5502);
+INSERT INTO includegroups(parentgroupid, includegroupid) VALUES(5504, 5502) ON CONFLICT DO NOTHING;
+INSERT INTO includegroups(parentgroupid, includegroupid) VALUES(5505, 5503) ON CONFLICT DO NOTHING;
+INSERT INTO includegroups(parentgroupid, includegroupid) VALUES(5505, 5502) ON CONFLICT DO NOTHING;
 
-INSERT INTO users(name, uidnumber, primarygroup, passsha256) VALUES ('hackers', 5002, 5502, '6478579e37aff45f013e14eeb30b3cc56c72ccdc310123bcdf53e0333e3f416a');
-INSERT INTO users(name, uidnumber, primarygroup, passsha256) VALUES('johndoe', 5003, 5503, '6478579e37aff45f013e14eeb30b3cc56c72ccdc310123bcdf53e0333e3f416a');
-INSERT INTO users(name, mail, uidnumber, primarygroup, passsha256) VALUES('serviceuser', 'serviceuser@example.com', 5004, 5503, '652c7dc687d98c9889304ed2e408c74b611e86a40caa51c4b43f1dd5913c5cd0');
-INSERT INTO users(name, uidnumber, primarygroup, passsha256, othergroups, custattr) VALUES('user4', 5005, 5502, '652c7dc687d98c9889304ed2e408c74b611e86a40caa51c4b43f1dd5913c5cd0', '5505,5506', '{"employeetype":["Intern","Temp"],"employeenumber":[12345,54321]}');
+INSERT INTO users(name, uidnumber, primarygroup, passsha256) VALUES ('hackers', 5002, 5502, '6478579e37aff45f013e14eeb30b3cc56c72ccdc310123bcdf53e0333e3f416a') ON CONFLICT DO NOTHING;
+INSERT INTO users(name, uidnumber, primarygroup, passsha256) VALUES('johndoe', 5003, 5503, '6478579e37aff45f013e14eeb30b3cc56c72ccdc310123bcdf53e0333e3f416a') ON CONFLICT DO NOTHING;
+INSERT INTO users(name, mail, uidnumber, primarygroup, passsha256) VALUES('serviceuser', 'serviceuser@example.com', 5004, 5503, '652c7dc687d98c9889304ed2e408c74b611e86a40caa51c4b43f1dd5913c5cd0') ON CONFLICT DO NOTHING;
+INSERT INTO users(name, uidnumber, primarygroup, passsha256, othergroups, custattr) VALUES('user4', 5005, 5502, '652c7dc687d98c9889304ed2e408c74b611e86a40caa51c4b43f1dd5913c5cd0', '5505,5506', '{"employeetype":["Intern","Temp"],"employeenumber":[12345,54321]}') ON CONFLICT DO NOTHING;
 
-INSERT INTO capabilities(userid, action, object) VALUES(5002, 'search', 'ou=superheros,dc=glauth,dc=com');
-INSERT INTO capabilities(userid, action, object) VALUES(5004, 'search', '*');
+INSERT INTO capabilities(userid, action, object) VALUES(5002, 'search', 'ou=superheros,dc=glauth,dc=com') ON CONFLICT DO NOTHING;
+INSERT INTO capabilities(userid, action, object) VALUES(5004, 'search', '*') ON CONFLICT DO NOTHING;

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -32,15 +32,6 @@ logger = logging.getLogger(__name__)
 @pytest.mark.skip_if_deployed
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
-    charm_lib_path = Path("lib/charms")
-    any_charm_src_overwrite = {
-        "any_charm.py": ANY_CHARM,
-        "ldap_interface_lib.py": (charm_lib_path / "glauth_k8s/v0/ldap.py").read_text(),
-        "certificate_transfer.py": (
-            charm_lib_path / "certificate_transfer_interface/v0/certificate_transfer.py"
-        ).read_text(),
-    }
-
     await asyncio.gather(
         ops_test.model.deploy(
             DB_APP,
@@ -51,14 +42,6 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
             CERTIFICATE_PROVIDER_APP,
             channel="stable",
             trust=True,
-        ),
-        ops_test.model.deploy(
-            GLAUTH_CLIENT_APP,
-            channel="beta",
-            config={
-                "src-overwrite": json.dumps(any_charm_src_overwrite),
-                "python-packages": "pydantic ~= 2.0\njsonschema\nldap3",
-            },
         ),
         ops_test.model.deploy(
             TRAEFIK_CHARM,
@@ -96,7 +79,6 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
         apps=[
             CERTIFICATE_PROVIDER_APP,
             DB_APP,
-            GLAUTH_CLIENT_APP,
             GLAUTH_APP,
             GLAUTH_PROXY,
             INGRESS_APP,
@@ -136,32 +118,6 @@ async def test_certification_integration(
     assert ingress_ip in extract_certificate_sans(certificate)
 
 
-async def test_ldap_integration(
-    ops_test: OpsTest,
-    app_integration_data: Callable,
-) -> None:
-    await ops_test.model.integrate(
-        f"{GLAUTH_CLIENT_APP}:ldap",
-        f"{GLAUTH_APP}:ldap",
-    )
-
-    await ops_test.model.wait_for_idle(
-        apps=[GLAUTH_APP, GLAUTH_CLIENT_APP],
-        status="active",
-        timeout=5 * 60,
-    )
-
-    integration_data = await app_integration_data(
-        GLAUTH_CLIENT_APP,
-        "ldap",
-    )
-    assert integration_data
-    assert integration_data["bind_dn"].startswith(
-        f"cn={GLAUTH_CLIENT_APP},ou={ops_test.model_name}"
-    )
-    assert integration_data["bind_password_secret"].startswith("secret:")
-
-
 async def test_ldap_client_integration(
     ops_test: OpsTest,
     app_integration_data: Callable,
@@ -177,136 +133,222 @@ async def test_ldap_client_integration(
     assert ldap_client_integration_data["bind_password_secret"].startswith("secret:")
 
 
-async def test_certificate_transfer_integration(
-    ops_test: OpsTest,
-    unit_integration_data: Callable,
-    ingress_ip: Optional[str],
-) -> None:
-    await ops_test.model.integrate(
-        f"{GLAUTH_CLIENT_APP}:send-ca-cert",
-        f"{GLAUTH_APP}:send-ca-cert",
-    )
+class GlauthClientTestSuite:
+    @pytest.fixture()
+    def ldap_client_app_name(self, pydantic_version: str) -> str:
+        return "".join([GLAUTH_CLIENT_APP, pydantic_version.replace(".", "")])
 
-    await ops_test.model.wait_for_idle(
-        apps=[GLAUTH_APP, GLAUTH_CLIENT_APP],
-        status="active",
-        timeout=5 * 60,
-    )
-
-    certificate_transfer_integration_data = await unit_integration_data(
-        GLAUTH_CLIENT_APP,
-        GLAUTH_APP,
-        "send-ca-cert",
-    )
-    assert certificate_transfer_integration_data, "Certificate transfer integration data is empty."
-
-    for key in ("ca", "certificate", "chain"):
-        assert key in certificate_transfer_integration_data, (
-            f"Missing '{key}' in certificate transfer integration data."
+    async def test_deploy_client_app(
+        self, ops_test: OpsTest, pydantic_version: str, ldap_client_app_name: str
+    ) -> None:
+        charm_lib_path = Path("lib/charms")
+        any_charm_src_overwrite = {
+            "any_charm.py": ANY_CHARM,
+            "ldap_interface_lib.py": (charm_lib_path / "glauth_k8s/v0/ldap.py").read_text(),
+            "certificate_transfer.py": (
+                charm_lib_path / "certificate_transfer_interface/v0/certificate_transfer.py"
+            ).read_text(),
+        }
+        await ops_test.model.deploy(
+            GLAUTH_CLIENT_APP,
+            application_name=ldap_client_app_name,
+            channel="beta",
+            config={
+                "src-overwrite": json.dumps(any_charm_src_overwrite),
+                "python-packages": f"pydantic ~= {pydantic_version}\njsonschema\nldap3",
+            },
         )
 
-    chain = certificate_transfer_integration_data["chain"]
-    assert isinstance(json.loads(chain), list), "Invalid certificate chain."
-
-    certificate = certificate_transfer_integration_data["certificate"]
-    assert (
-        f"CN={GLAUTH_APP}.{ops_test.model_name}.svc.cluster.local"
-        == extract_certificate_common_name(certificate)
-    )
-    assert ingress_ip in extract_certificate_sans(certificate)
-
-
-@pytest.mark.skip(
-    reason="glauth cannot scale up due to the traefik-k8s issue: https://github.com/canonical/traefik-k8s-operator/issues/406",
-)
-async def test_glauth_scale_up(ops_test: OpsTest) -> None:
-    app, target_unit_num = ops_test.model.applications[GLAUTH_APP], 2
-
-    await app.scale(target_unit_num)
-
-    await ops_test.model.wait_for_idle(
-        apps=[GLAUTH_APP],
-        status="active",
-        timeout=5 * 60,
-        wait_for_exact_units=target_unit_num,
-    )
-
-
-@pytest.mark.skip(
-    reason="cert_handler is bugged, remove this once it is fixed or when we throw it away..."
-)
-async def test_glauth_scale_down(ops_test: OpsTest) -> None:
-    app, target_unit_num = ops_test.model.applications[GLAUTH_APP], 1
-
-    await app.scale(target_unit_num)
-    await ops_test.model.wait_for_idle(
-        apps=[GLAUTH_APP],
-        status="active",
-        timeout=5 * 60,
-    )
-
-
-async def test_ldap_search_operation(
-    initialize_database: None,
-    ldap_configurations: Optional[tuple[str, ...]],
-    ingress_url: Optional[str],
-) -> None:
-    assert ldap_configurations, "LDAP configuration should be ready"
-    base_dn, bind_dn, bind_password = ldap_configurations
-
-    ldap_uri = f"ldap://{ingress_url}"
-    with ldap_connection(uri=ldap_uri, bind_dn=bind_dn, bind_password=bind_password) as conn:
-        res = conn.search_s(
-            base=base_dn,
-            scope=ldap.SCOPE_SUBTREE,
-            filterstr="(cn=hackers)",
+        await ops_test.model.wait_for_idle(
+            apps=[ldap_client_app_name],
+            status="active",
+            raise_on_blocked=False,
+            timeout=5 * 60,
         )
 
-    assert res[0], "Can't find user 'hackers'"
-    dn, _ = res[0]
-    assert dn == f"cn=hackers,ou=superheros,ou=users,{base_dn}"
-
-    with ldap_connection(
-        uri=ldap_uri, bind_dn=f"cn=serviceuser,ou=svcaccts,{base_dn}", bind_password="mysecret"
-    ) as conn:
-        res = conn.search_s(
-            base=base_dn,
-            scope=ldap.SCOPE_SUBTREE,
-            filterstr="(cn=johndoe)",
+    async def test_ldap_integration(
+        self,
+        ops_test: OpsTest,
+        app_integration_data: Callable,
+        ldap_client_app_name: str,
+    ) -> None:
+        await ops_test.model.integrate(
+            f"{ldap_client_app_name}:ldap",
+            f"{GLAUTH_APP}:ldap",
         )
 
-    assert res[0], "User 'johndoe' can't be found by using 'serviceuser' as bind DN"
-    dn, _ = res[0]
-    assert dn == f"cn=johndoe,ou=svcaccts,ou=users,{base_dn}"
-
-    with ldap_connection(
-        uri=ldap_uri, bind_dn=f"cn=hackers,ou=superheros,{base_dn}", bind_password="dogood"
-    ) as conn:
-        user4 = conn.search_s(
-            base=f"ou=superheros,{base_dn}", scope=ldap.SCOPE_SUBTREE, filterstr="(cn=user4)"
+        await ops_test.model.wait_for_idle(
+            apps=[GLAUTH_APP, ldap_client_app_name],
+            status="active",
+            timeout=5 * 60,
         )
 
-    assert user4[0], "User 'user4' can't be found by using 'hackers' as bind DN"
-    dn, _ = user4[0]
-    assert dn == f"cn=user4,ou=superheros,{base_dn}"
+        integration_data = await app_integration_data(
+            ldap_client_app_name,
+            "ldap",
+        )
+        assert integration_data
+        assert integration_data["bind_dn"].startswith(
+            f"cn={ldap_client_app_name},ou={ops_test.model_name}"
+        )
+        assert integration_data["bind_password_secret"].startswith("secret:")
 
-    with (
-        ldap_connection(
+    async def test_certificate_transfer_integration(
+        self,
+        ops_test: OpsTest,
+        unit_integration_data: Callable,
+        ingress_ip: Optional[str],
+        ldap_client_app_name: str,
+    ) -> None:
+        await ops_test.model.integrate(
+            f"{ldap_client_app_name}:send-ca-cert",
+            f"{GLAUTH_APP}:send-ca-cert",
+        )
+
+        await ops_test.model.wait_for_idle(
+            apps=[GLAUTH_APP, ldap_client_app_name],
+            status="active",
+            timeout=5 * 60,
+        )
+
+        certificate_transfer_integration_data = await unit_integration_data(
+            ldap_client_app_name,
+            GLAUTH_APP,
+            "send-ca-cert",
+        )
+        assert (
+            certificate_transfer_integration_data
+        ), "Certificate transfer integration data is empty."
+
+        for key in ("ca", "certificate", "chain"):
+            assert (
+                key in certificate_transfer_integration_data
+            ), f"Missing '{key}' in certificate transfer integration data."
+
+        chain = certificate_transfer_integration_data["chain"]
+        assert isinstance(json.loads(chain), list), "Invalid certificate chain."
+
+        certificate = certificate_transfer_integration_data["certificate"]
+        assert (
+            f"CN={GLAUTH_APP}.{ops_test.model_name}.svc.cluster.local"
+            == extract_certificate_common_name(certificate)
+        )
+        assert ingress_ip in extract_certificate_sans(certificate)
+
+    @pytest.mark.skip(
+        reason="glauth cannot scale up due to the traefik-k8s issue: https://github.com/canonical/traefik-k8s-operator/issues/406",
+    )
+    async def test_glauth_scale_up(self, ops_test: OpsTest) -> None:
+        app, target_unit_num = ops_test.model.applications[GLAUTH_APP], 2
+
+        await app.scale(target_unit_num)
+
+        await ops_test.model.wait_for_idle(
+            apps=[GLAUTH_APP],
+            status="active",
+            timeout=5 * 60,
+            wait_for_exact_units=target_unit_num,
+        )
+
+    @pytest.mark.skip(
+        reason="cert_handler is bugged, remove this once it is fixed or when we throw it away..."
+    )
+    async def test_glauth_scale_down(self, ops_test: OpsTest) -> None:
+        app, target_unit_num = ops_test.model.applications[GLAUTH_APP], 1
+
+        await app.scale(target_unit_num)
+        await ops_test.model.wait_for_idle(
+            apps=[GLAUTH_APP],
+            status="active",
+            timeout=5 * 60,
+        )
+
+    async def test_ldap_search_operation(
+        self,
+        initialize_database: None,
+        ldap_configurations: Optional[tuple[str, ...]],
+        ingress_url: Optional[str],
+    ) -> None:
+        assert ldap_configurations, "LDAP configuration should be ready"
+        base_dn, bind_dn, bind_password = ldap_configurations
+
+        ldap_uri = f"ldap://{ingress_url}"
+        with ldap_connection(uri=ldap_uri, bind_dn=bind_dn, bind_password=bind_password) as conn:
+            res = conn.search_s(
+                base=base_dn,
+                scope=ldap.SCOPE_SUBTREE,
+                filterstr="(cn=hackers)",
+            )
+
+        assert res[0], "Can't find user 'hackers'"
+        dn, _ = res[0]
+        assert dn == f"cn=hackers,ou=superheros,ou=users,{base_dn}"
+
+        with ldap_connection(
+            uri=ldap_uri, bind_dn=f"cn=serviceuser,ou=svcaccts,{base_dn}", bind_password="mysecret"
+        ) as conn:
+            res = conn.search_s(
+                base=base_dn,
+                scope=ldap.SCOPE_SUBTREE,
+                filterstr="(cn=johndoe)",
+            )
+
+        assert res[0], "User 'johndoe' can't be found by using 'serviceuser' as bind DN"
+        dn, _ = res[0]
+        assert dn == f"cn=johndoe,ou=svcaccts,ou=users,{base_dn}"
+
+        with ldap_connection(
             uri=ldap_uri, bind_dn=f"cn=hackers,ou=superheros,{base_dn}", bind_password="dogood"
-        ) as conn,
-        pytest.raises(ldap.INSUFFICIENT_ACCESS),
-    ):
-        conn.search_s(base=base_dn, scope=ldap.SCOPE_SUBTREE, filterstr="(cn=user4)")
+        ) as conn:
+            user4 = conn.search_s(
+                base=f"ou=superheros,{base_dn}", scope=ldap.SCOPE_SUBTREE, filterstr="(cn=user4)"
+            )
+
+        assert user4[0], "User 'user4' can't be found by using 'hackers' as bind DN"
+        dn, _ = user4[0]
+        assert dn == f"cn=user4,ou=superheros,{base_dn}"
+
+        with (
+            ldap_connection(
+                uri=ldap_uri, bind_dn=f"cn=hackers,ou=superheros,{base_dn}", bind_password="dogood"
+            ) as conn,
+            pytest.raises(ldap.INSUFFICIENT_ACCESS),
+        ):
+            conn.search_s(base=base_dn, scope=ldap.SCOPE_SUBTREE, filterstr="(cn=user4)")
+
+    async def test_ldap_starttls_operation(
+        self,
+        ldap_configurations: Optional[tuple[str, ...]],
+        run_action: Callable,
+        ldap_client_app_name: str,
+    ) -> None:
+        assert ldap_configurations, "LDAP configuration should be ready"
+        base_dn, *_ = ldap_configurations
+
+        res = await run_action(
+            ldap_client_app_name, "rpc", method="starttls_operation", cn="hackers"
+        )
+        ret = json.loads(res["return"])
+        assert ret, "Can't find user 'hackers'"
+        assert ret["dn"] == f"cn=hackers,ou=superheros,ou=users,{base_dn}"
+
+    async def test_remove_client_app(self, ops_test: OpsTest, ldap_client_app_name: str) -> None:
+        await ops_test.model.remove_application(ldap_client_app_name, force=True)
+        await ops_test.model.wait_for_idle(
+            apps=[GLAUTH_APP],
+            status="active",
+            raise_on_blocked=False,
+            timeout=5 * 60,
+        )
 
 
-async def test_ldap_starttls_operation(
-    ldap_configurations: Optional[tuple[str, ...]],
-    run_action: Callable,
-) -> None:
-    assert ldap_configurations, "LDAP configuration should be ready"
-    base_dn, *_ = ldap_configurations
+class TestGlauthClientPydanticV2(GlauthClientTestSuite):
+    @pytest.fixture()
+    def pydantic_version(self) -> str:
+        return "2.0"
 
-    res = await run_action(GLAUTH_CLIENT_APP, "rpc", method="starttls_operation", cn="hackers")
-    ret = json.loads(res["return"])
-    assert ret, "Can't find user 'hackers'"
-    assert ret["dn"] == f"cn=hackers,ou=superheros,ou=users,{base_dn}"
+
+class TestGlauthClientPydanticV1(GlauthClientTestSuite):
+    @pytest.fixture()
+    def pydantic_version(self) -> str:
+        return "1.0"

--- a/tests/unit/test_ldap_requirer.py
+++ b/tests/unit/test_ldap_requirer.py
@@ -1,0 +1,165 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+from typing import Any, Dict, Generator, List
+
+import pytest
+from charms.glauth_k8s.v0.ldap import LdapReadyEvent, LdapRequirer, LdapUnavailableEvent
+from ops import CharmBase, EventBase
+from ops.testing import Harness
+
+METADATA = """
+name: requirer-tester
+requires:
+  ldap:
+    interface: ldap
+"""
+
+
+@pytest.fixture()
+def harness() -> Generator:
+    harness = Harness(LdapRequirerCharm, meta=METADATA)
+    harness.set_leader(True)
+    harness.set_model_name("test")
+    harness.begin_with_initial_hooks()
+    yield harness
+    harness.cleanup()
+
+
+@pytest.fixture()
+def provider_data() -> Dict[str, str]:
+    return {
+        "urls": '["ldap://path.to.glauth:3893"]',
+        "base_dn": "dc=glauth,dc=com",
+        "starttls": "true",
+        "bind_dn": "cn=serviceuser,ou=svcaccts,dc=glauth,dc=com",
+        "bind_password_secret": "",
+        "auth_method": "simple",
+    }
+
+
+@pytest.fixture()
+def requirer_data() -> Dict[str, str]:
+    return {
+        "user": "requirer-tester",
+        "group": "test",
+    }
+
+
+def dict_to_relation_data(dic: Dict) -> Dict:
+    return {k: json.dumps(v) if isinstance(v, (list, dict)) else v for k, v in dic.items()}
+
+
+class LdapRequirerCharm(CharmBase):
+    def __init__(self, *args: Any) -> None:
+        super().__init__(*args)
+        self.events: List[EventBase] = []
+        self.ldap_requirer = LdapRequirer(self)
+        self.framework.observe(
+            self.ldap_requirer.on.ldap_ready,
+            self._record_event,
+        )
+        self.framework.observe(
+            self.ldap_requirer.on.ldap_unavailable,
+            self._record_event,
+        )
+
+    def _record_event(self, event: EventBase) -> None:
+        self.events.append(event)
+
+
+def test_data_in_relation_bag(harness: Harness, requirer_data: Dict) -> None:
+    relation_id = harness.add_relation("ldap", "provider")
+
+    relation_data = harness.get_relation_data(relation_id, harness.model.app.name)
+
+    assert relation_data == dict_to_relation_data(requirer_data)
+
+
+def test_event_emitted_when_ldap_is_ready(
+    harness: Harness,
+    provider_data: Dict,
+    requirer_data: Dict,
+) -> None:
+    relation_id = harness.add_relation("ldap", "provider")
+    harness.add_relation_unit(relation_id, "provider/0")
+    harness.update_relation_data(
+        relation_id,
+        "provider",
+        provider_data,
+    )
+    relation_data = harness.get_relation_data(relation_id, harness.model.app.name)
+    events = harness.charm.events
+
+    assert relation_data == dict_to_relation_data(requirer_data)
+    assert len(events) == 1
+    assert isinstance(events[0], LdapReadyEvent)
+
+
+def test_event_emitted_when_relation_removed(
+    harness: Harness,
+    provider_data: Dict,
+    requirer_data: Dict,
+) -> None:
+    relation_id = harness.add_relation("ldap", "provider")
+    harness.add_relation_unit(relation_id, "provider/0")
+    harness.remove_relation(relation_id)
+
+    events = harness.charm.events
+
+    assert len(events) == 1
+    assert isinstance(events[0], LdapUnavailableEvent)
+
+
+def test_consume_ldap_relation_data(harness: Harness, provider_data: Dict) -> None:
+    password = "p4ssw0rd"
+    relation_id = harness.add_relation("ldap", "provider")
+    harness.add_relation_unit(relation_id, "provider/0")
+    secret_id = harness.add_model_secret("provider", {"password": password})
+    harness.grant_secret(secret_id, "requirer-tester")
+    provider_data["bind_password_secret"] = secret_id
+    harness.update_relation_data(
+        relation_id,
+        "provider",
+        provider_data,
+    )
+
+    charm: LdapRequirerCharm = harness.charm
+    data = charm.ldap_requirer.consume_ldap_relation_data()
+
+    assert data
+    assert data.auth_method == provider_data["auth_method"]
+    assert data.base_dn == provider_data["base_dn"]
+    assert data.bind_dn == provider_data["bind_dn"]
+    assert data.bind_password == password
+    assert data.bind_password_secret == provider_data["bind_password_secret"]
+
+
+def test_not_ready(harness: Harness, provider_data: Dict) -> None:
+    relation_id = harness.add_relation("ldap", "provider")
+    harness.add_relation_unit(relation_id, "provider/0")
+    provider_data.pop("urls")
+    harness.update_relation_data(
+        relation_id,
+        "provider",
+        provider_data,
+    )
+
+    charm: LdapRequirerCharm = harness.charm
+
+    assert not charm.ldap_requirer.ready()
+
+
+def test_ready(harness: Harness, provider_data: Dict) -> None:
+    relation_id = harness.add_relation("ldap", "provider")
+    harness.add_relation_unit(relation_id, "provider/0")
+    harness.update_relation_data(
+        relation_id,
+        "provider",
+        provider_data,
+    )
+
+    charm: LdapRequirerCharm = harness.charm
+
+    assert charm.ldap_requirer.ready()

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = fmt, lint, unit
+envlist = fmt, lint, unit, unit-pydantic-v1
 
 [vars]
 src_path = {toxinidir}/src/
@@ -62,6 +62,21 @@ commands =
                  --ignore={[vars]tst_path}integration \
                  -vv \
                  --tb native \
+                 -s {posargs}
+    coverage report
+
+[testenv:unit-pydantic-v1]
+description = Run unit tests
+deps =
+    -r{toxinidir}/unit-requirements.txt
+commands =
+    pip install pydantic~=1.0
+    coverage run --source={[vars]src_path},{[vars]lib_path} \
+                 -m pytest \
+                 --ignore={[vars]tst_path}integration \
+                 -vv \
+                 --tb native \
+                 -k "not TestLdapAuxiliaryRequestedEvent" \
                  -s {posargs}
     coverage report
 


### PR DESCRIPTION
IAM-1284

Adds support for pydantic v1 in the ldap library. The compatibility layer in the `ldap` library is quite hacky and custom to our use, if someone has a better solution I'd be happy to change it.

The integration tests with any charm will now run for both v1 and v2 pydantic. Also added a new tox environment so that the unit tests can run for v1 as well. I did not apply the same logic for the auxiliary relation, as v1 support shouldn't be required there.