### PR TITLE
fix: Write ldaps_urls only if ldaps_enabled

### DIFF
--- a/src/integrations.py
+++ b/src/integrations.py
@@ -129,6 +129,9 @@ class LdapIntegration:
 
     @property
     def ldaps_urls(self) -> List[str]:
+        if not self.ldaps_enabled:
+            return []
+
         if ingress := self._charm.ldaps_ingress_per_unit.urls:
             return [f"ldaps://{url}" for url in ingress.values()]
 


### PR DESCRIPTION
In #103 I forgot to conditionally add the ldaps_urls.
The `ldaps_urls` was always added which should not be the case.

This PR fixes this and adds a test to ensure that the field is updated on config changed.