### PR TITLE
fix: add `trust = true` to tf module

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,6 +4,7 @@
 resource "juju_application" "glauth-k8s" {
   name  = var.app_name
   model = var.model_name
+  trust = true
 
   charm {
     name     = "glauth-k8s"


### PR DESCRIPTION
`trust` must be set to true since the operator accesses the Kubernetes API. Without this option set in the Terraform module, glauth-k8s will fail to deploy as part of a Terraform plan.