### PR TITLE
chore: bump `upstream-source` for oci-image to 2.4.0

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -21,7 +21,7 @@ resources:
   oci-image:
     type: oci-image
     description: GLAuth oci-image
-    upstream-source: ghcr.io/canonical/glauth:2.3.1
+    upstream-source: ghcr.io/canonical/glauth:2.4.0
 
 requires:
   pg-database:


### PR DESCRIPTION
Bumps the upstream source for the GLAuth oci image to the newly released 2.4.0.

Does this require a manual release of the image in Charmhub? I'm not sure if the CI also publishes that automatically.