### PR TITLE
fix: set default for `var.constraints` to `"arch=amd64"`

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,7 +20,7 @@ variable "config" {
 variable "constraints" {
   description = "The constraints to be applied"
   type        = string
-  default     = ""
+  default     = "arch=amd64"
 }
 
 variable "units" {


### PR DESCRIPTION
Fixes #143 