### PR TITLE
fix: return `None` when `bind_password` secret is inaccessible to requirer

### DIFF
--- a/lib/charms/glauth_k8s/v0/ldap.py
+++ b/lib/charms/glauth_k8s/v0/ldap.py
@@ -147,7 +147,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 11
+LIBPATCH = 12
 
 PYDEPS = ["pydantic"]
 
@@ -501,13 +501,12 @@ class LdapRequirer(Object):
         self.on.ldap_unavailable.emit(event.relation)
 
     def _load_provider_data(self, provider_data: dict) -> Optional[LdapProviderData]:
-        if secret_id := provider_data.get("bind_password_secret"):
+        try:
+            secret_id = provider_data.get("bind_password_secret")
             secret = self.charm.model.get_secret(id=secret_id)
             provider_data["bind_password"] = secret.get_content().get("password")
-
-        try:
             return LdapProviderData(**provider_data)
-        except ValidationError:
+        except (ops.ModelError, ops.SecretNotFoundError, TypeError, ValidationError):
             return None
 
     def consume_ldap_relation_data(

--- a/tests/unit/test_ldap_requirer.py
+++ b/tests/unit/test_ldap_requirer.py
@@ -143,6 +143,26 @@ def test_consume_ldap_relation_data(harness: Harness, provider_data: Dict) -> No
     assert data.bind_password_secret == provider_data["bind_password_secret"]
 
 
+def test_consume_ldap_relation_data_inaccessible_secret(
+    harness: Harness, provider_data: Dict
+) -> None:
+    password = "p4ssw0rd"
+    relation_id = harness.add_relation("ldap", "provider")
+    harness.add_relation_unit(relation_id, "provider/0")
+    secret_id = harness.add_model_secret("provider", {"password": password})
+    provider_data["bind_password_secret"] = secret_id
+    harness.update_relation_data(
+        relation_id,
+        "provider",
+        provider_data,
+    )
+
+    charm: LdapRequirerCharm = harness.charm
+    data = charm.ldap_requirer.consume_ldap_relation_data()
+
+    assert data is None
+
+
 def test_not_ready(harness: Harness, provider_data: Dict) -> None:
     relation_id = harness.add_relation("ldap", "provider")
     harness.add_relation_unit(relation_id, "provider/0")


### PR DESCRIPTION
This PR fixes #204 by updating the `_load_provider_data` method in the LDAP charm library to return `None` if the bind password secret is inaccessible to the requirer charm. 

This is accomplished by updating the method to catch both the `ops.ModelError` and `ops.SecretNotFoundError` exceptions that can be raised by the `get_secret` and `get_content` methods. This PR also switches the structure of `_load_provider_data` from "Ask for permission" to "Ask for forgiveness" so that there only needs to be one `try`/`except` block in `_load_provider_data`. `get_secret()` will raise a `TypeError` if the value of both the `id` and `label` keyword arguments are `None`.

I also added a unit test to check that `consume_ldap_relation_data` returns `None` if the requirer charm has not been granted access to the bind password secret.
