### PR TITLE
feat: expose active relations on ldap providers

### DIFF
--- a/lib/charms/glauth_k8s/v0/ldap.py
+++ b/lib/charms/glauth_k8s/v0/ldap.py
@@ -147,7 +147,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 12
+LIBPATCH = 13
 
 PYDEPS = ["pydantic"]
 
@@ -373,7 +373,35 @@ class LdapRequirerEvents(ObjectEvents):
     ldap_unavailable = EventSource(LdapUnavailableEvent)
 
 
-class LdapProvider(Object):
+class _LdapInterface(Object):
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME) -> None:
+        super().__init__(charm, relation_name)
+
+        self.charm = charm
+        self.app = charm.app
+        self.unit = charm.unit
+        self._relation_name = relation_name
+
+    @property
+    def relations(self) -> List[Relation]:
+        """The list of Relation instances associated with this relation_name."""
+        return [
+            relation
+            for relation in self.charm.model.relations[self._relation_name]
+            if self._is_relation_active(relation)
+        ]
+
+    @staticmethod
+    def _is_relation_active(relation: Relation) -> bool:
+        """Whether the relation is active based on contained data."""
+        try:
+            _ = repr(relation.data)
+            return True
+        except (RuntimeError, ops.ModelError):
+            return False
+
+
+class LdapProvider(_LdapInterface):
     on = LdapProviderEvents()
 
     def __init__(
@@ -382,11 +410,6 @@ class LdapProvider(Object):
         relation_name: str = DEFAULT_RELATION_NAME,
     ) -> None:
         super().__init__(charm, relation_name)
-
-        self.charm = charm
-        self.app = charm.app
-        self.unit = charm.unit
-        self._relation_name = relation_name
 
         self.framework.observe(
             self.charm.on[self._relation_name].relation_changed,
@@ -446,7 +469,7 @@ class LdapProvider(Object):
             _update_relation_app_databag(self.charm, relation, data.model_dump())
 
 
-class LdapRequirer(Object):
+class LdapRequirer(_LdapInterface):
     """An LDAP requirer to consume data delivered by an LDAP provider charm."""
 
     on = LdapRequirerEvents()
@@ -460,10 +483,6 @@ class LdapRequirer(Object):
     ) -> None:
         super().__init__(charm, relation_name)
 
-        self.charm = charm
-        self.app = charm.app
-        self.unit = charm.unit
-        self._relation_name = relation_name
         self._data = data
 
         self.framework.observe(
@@ -527,23 +546,6 @@ class LdapRequirer(Object):
             return None
 
         return self._load_provider_data(provider_data)
-
-    def _is_relation_active(self, relation: Relation) -> bool:
-        """Whether the relation is active based on contained data."""
-        try:
-            _ = repr(relation.data)
-            return True
-        except (RuntimeError, ops.ModelError):
-            return False
-
-    @property
-    def relations(self) -> List[Relation]:
-        """The list of Relation instances associated with this relation_name."""
-        return [
-            relation
-            for relation in self.charm.model.relations[self._relation_name]
-            if self._is_relation_active(relation)
-        ]
 
     def _ready_for_relation(self, relation: Relation) -> bool:
         if not relation.app:


### PR DESCRIPTION
This PR reworks the private API of the `ldap` charm library so that active LDAP integrations can be accessed by charms implementing either the `LdapRequirer` or `LdapProvider` classes using the `relations` property. This is accomplished by introducing the private `_LdapInterface` class, which holds common code between the two classes such as aliases to `unit`/`app`/`charm` and the `relations` property.

I'm introducing this change to address https://github.com/canonical/ldap-integrator/issues/127. I want to use the `relations` property added to the `LdapProvider` class here to iterate over all the existing LDAP integrations when updating the integrator's configuration. Rather than only update the first LDAP integration in the `RelationMapping` objects, the `relations` property can be used to update all the LDAP integration instances, thus enabling a one-to-many integration between `ldap-integrator` and `sssd`:

```python
# Assume we're in LdapIntegratorCharm.

def _holistic_event_handler(self, event: ops.EventBase) -> None:
    ...
    
    for integration in self.ldap.relations:
        self.ldap.update_relations_app_data(data, relation_id=integration.id)
````

The reason why I need to pass all the relation/integration ids to `update_relations_app_data` method is because of how it scopes a bind password secret to each integration instance. The bind password secret will not be updated if a relation id is not passed, potentially leaving LDAP clients with a stale bind password for accessing the external LDAP server.

