### PR TITLE
feat: update terraform module to juju provider ~> 1.0

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -7,7 +7,7 @@
 
 resource "juju_application" "glauth_k8s" {
   name        = var.app_name
-  model       = var.model_name
+  model_uuid  = var.model_uuid
   trust       = true
   config      = var.config
   constraints = var.constraints

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,14 +1,15 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-variable "model_name" {
-  description = "The Juju model name"
+variable "model_uuid" {
+  description = "The Juju model UUID"
   type        = string
 }
 
 variable "app_name" {
   description = "The Juju application name"
   type        = string
+  default     = "glauth-k8s"
 }
 
 variable "config" {
@@ -20,7 +21,7 @@ variable "config" {
 variable "constraints" {
   description = "The constraints to be applied"
   type        = string
-  default     = "arch=amd64"
+  default     = ""
 }
 
 variable "units" {

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.16.0"
+      version = "~> 1.0"
     }
   }
 


### PR DESCRIPTION
This tiny PR updates the glauth-k8s Terraform module to use v1 of the Juju Terraform provider. The most noticeable change is that `model_uuid` is used instead of `model_name`. Also, the default value for the `constraints` variable can now be an empty string rather than `arch=amd64`.

That said, another thing I wasn't so sure about was the default value for `app_name`. I noticed that a name isn't set by default when I was testing the module, so I updated the default value to be `glauth-k8s`. I generally set the operator name as the default name in my charms' Terraform modules since that is Juju's default behavior when you don't supply an application name at the command line. Let me know if you want me to yoink this change or not.