### PR TITLE
Address missing IP SANs in certificate due to missing restart

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -259,11 +259,11 @@ class GLAuthCharm(CharmBase):
         backend_not_ready,
         tls_certificates_not_ready,
     )
-    def _handle_event_update(self, event: HookEvent) -> None:
+    def _handle_event_update(self, event: HookEvent, restart: bool = False) -> None:
         self._update_glauth_config()
         self._container.add_layer(WORKLOAD_CONTAINER, pebble_layer, combine=True)
 
-        self._restart_glauth_service(restart=self.config_changed)
+        self._restart_glauth_service(restart=restart or self.config_changed)
         self.unit.status = ActiveStatus()
 
     @property
@@ -409,7 +409,7 @@ class GLAuthCharm(CharmBase):
             )
             return
 
-        self._handle_event_update(event)
+        self._handle_event_update(event, restart=True)
         self._certs_transfer_integration.transfer_certificates(
             self._certs_integration.cert_data,
         )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -470,6 +470,7 @@ class TestCertChangedEvent:
         context: Context,
         mocker: MagicMock,
         mocked_tls_certificates: MagicMock,
+        mocked_restart_glauth_service: MagicMock,
         certificates_relation: Relation,
         db_relation_ready: Relation,
         csr: CertificateSigningRequest,
@@ -495,6 +496,7 @@ class TestCertChangedEvent:
 
         mock_update.assert_called_once()
         mock_transfer.assert_called_once()
+        mocked_restart_glauth_service.assert_called_with(restart=True)
 
 
 class TestCertificatesTransferEvent:


### PR DESCRIPTION
- **fix(charm): restart glauth service on certificate changes**
- **test(unit): assert glauth service restart on certificate change event**
